### PR TITLE
fix(sdk): make hex optional in ColorSchema

### DIFF
--- a/.changeset/fix-optional-hex.md
+++ b/.changeset/fix-optional-hex.md
@@ -1,0 +1,5 @@
+---
+"@nike-release-checker/sdk": patch
+---
+
+fix(sdk): make `hex` optional in product feed `ColorSchema` to handle Nike API responses missing the field

--- a/packages/sdk/productFeed/schema.ts
+++ b/packages/sdk/productFeed/schema.ts
@@ -289,7 +289,7 @@ export const ColorTypeSchema = v.union([
 ])
 
 export const ColorSchema = v.object({
-	hex: v.string(),
+	hex: v.optional(v.string()),
 	name: v.string(),
 	type: ColorTypeSchema,
 })


### PR DESCRIPTION
The live Nike API now returns color objects without the hex field for
some regions (e.g. CZ). Make it optional since it's not used downstream.

https://claude.ai/code/session_01NR78JnmRhLZePY9G6xq8AM