### PR TITLE
fix(sdk): support URL destination type in ProductFeed schema

### DIFF
--- a/.changeset/fix-destination-url-type.md
+++ b/.changeset/fix-destination-url-type.md
@@ -1,0 +1,5 @@
+---
+"@nike-release-checker/sdk": patch
+---
+
+Fix ProductFeed DestinationSchema to support URL destination type

--- a/packages/sdk/productFeed/schema.ts
+++ b/packages/sdk/productFeed/schema.ts
@@ -579,10 +579,19 @@ export const JSONBodySchema = v.object({
 	type: v.literal('doc'),
 })
 
-export const DestinationSchema = v.object({
-	product: ProductSchema,
-	type: v.union([v.literal('BUYING_TOOLS'), v.literal('THREAD_ID')]),
-})
+export const DestinationSchema = v.variant('type', [
+	v.object({
+		product: ProductSchema,
+		type: v.literal('BUYING_TOOLS'),
+	}),
+	v.object({
+		product: ProductSchema,
+		type: v.literal('THREAD_ID'),
+	}),
+	v.object({
+		type: v.literal('URL'),
+	}),
+])
 
 export const ActionSchema = v.object({
 	actionType: v.union([v.literal('cta_buying_tools'), v.literal('minicard_link')]),


### PR DESCRIPTION
The Nike API now returns destination.type: "URL" for some actions, but DestinationSchema only allowed "BUYING_TOOLS" | "THREAD_ID" and required a product field. Switch to a discriminated union (v.variant) that supports all three types, with product required for BUYING_TOOLS/THREAD_ID and omitted for URL.

https://claude.ai/code/session_01JsW8PSx6WkW9d5bJSaJCAN