### PR TITLE
fix: make styleType optional in AvailableGtinSchema

### DIFF
--- a/.changeset/fix-styletype-validation.md
+++ b/.changeset/fix-styletype-validation.md
@@ -1,0 +1,5 @@
+---
+"@nike-release-checker/sdk": patch
+---
+
+Make `styleType` optional in `AvailableGtinSchema` to handle API responses where the field is absent

--- a/packages/sdk/productFeed/schema.ts
+++ b/packages/sdk/productFeed/schema.ts
@@ -111,7 +111,7 @@ export const AvailableGtinSchema = v.object({
 	locationId: LocationIDSchema,
 	method: v.literal('SHIP'),
 	styleColor: v.string(),
-	styleType: v.literal('INLINE'),
+	styleType: v.optional(v.literal('INLINE')),
 })
 
 export const FastAvailabilitySchema = v.object({


### PR DESCRIPTION
The Nike API sometimes returns availableGtins entries without a
styleType field. Making it optional prevents validation failures
for IE and other regions where this occurs in the live feed.

https://claude.ai/code/session_01CK84LUq8uttZ4Ch952QsBC