### PR TITLE
fix: allow 'light' value for colorTheme in product feed schemas

### DIFF
--- a/.changeset/fix-color-theme-validation.md
+++ b/.changeset/fix-color-theme-validation.md
@@ -1,0 +1,5 @@
+---
+"@nike-release-checker/sdk": patch
+---
+
+Allow `"light"` as a valid `colorTheme` value in `PublishedContentNodePropertiesSchema` and `PurplePropertiesSchema`

--- a/packages/sdk/productFeed/schema.ts
+++ b/packages/sdk/productFeed/schema.ts
@@ -600,7 +600,7 @@ export const PublishedContentNodePropertiesSchema = v.object({
 	altText: v.optional(v.string()),
 	autoPlay: v.optional(v.boolean()),
 	body: v.optional(v.string()),
-	colorTheme: v.literal('dark'),
+	colorTheme: v.union([v.literal('dark'), v.literal('light')]),
 	containerType: v.optional(ContainerTypeEnumSchema),
 	copyId: v.string(),
 	custom: v.optional(v.unknown()),
@@ -637,7 +637,7 @@ export const PublishedContentNodePropertiesSchema = v.object({
 export const PurplePropertiesSchema = v.object({
 	actions: v.array(v.unknown()),
 	altText: v.string(),
-	colorTheme: v.literal('dark'),
+	colorTheme: v.union([v.literal('dark'), v.literal('light')]),
 	copyId: v.string(),
 	custom: v.optional(v.unknown()),
 	fallbacks: v.optional(v.array(v.unknown())),


### PR DESCRIPTION
PublishedContentNodePropertiesSchema and PurplePropertiesSchema were
restricting colorTheme to only 'dark', causing CI validation failures
when the Nike PT product feed returns nodes with colorTheme: 'light'.
Updated both to match CoverCardPropertiesSchema which already accepted
both values.

https://claude.ai/code/session_01PU4awT9ykQuTPMpTLDFQTb