### PR TITLE
Make collection fields optional in product feed schema

### DIFF
--- a/.changeset/fix-product-feed-optional-collection-fields.md
+++ b/.changeset/fix-product-feed-optional-collection-fields.md
@@ -1,0 +1,5 @@
+---
+"@nike-release-checker/sdk": patch
+---
+
+Make `collectionTermIds` and `groupedCollectionTermIds` optional in product feed schema to handle API responses that omit these fields (e.g. SG marketplace).

--- a/packages/sdk/productFeed/schema.ts
+++ b/packages/sdk/productFeed/schema.ts
@@ -61,8 +61,8 @@ export const MarketplaceSchema = v.union([
 ])
 
 export const Collectionsv2Schema = v.object({
-	collectionTermIds: v.array(v.unknown()),
-	groupedCollectionTermIds: v.unknown(),
+	collectionTermIds: v.optional(v.array(v.unknown())),
+	groupedCollectionTermIds: v.optional(v.unknown()),
 })
 
 export const SelfSchema = v.object({
@@ -722,7 +722,7 @@ export const ProductFeedSchema = v.object({
 	channelId: v.string(),
 	channelName: v.string(),
 	collectionsv2: Collectionsv2Schema,
-	collectionTermIds: v.array(v.unknown()),
+	collectionTermIds: v.optional(v.array(v.unknown())),
 	id: v.string(),
 	language: v.string(),
 	lastFetchTime: v.string(),


### PR DESCRIPTION
## Summary
Updated the product feed schema to make collection-related fields optional, allowing the SDK to handle API responses that omit these fields.

## Changes
- Made `collectionTermIds` optional in `Collectionsv2Schema`
- Made `groupedCollectionTermIds` optional in `Collectionsv2Schema`
- Made `collectionTermIds` optional in `ProductFeedSchema`

## Details
These fields are not always present in API responses from all marketplaces (e.g., SG marketplace). By marking them as optional in the schema validation, the SDK can now gracefully handle responses that omit these fields without validation errors.

https://claude.ai/code/session_01G9sfpMCFDNZPjsEYVzv4ko