### PR TITLE
fix(sdk): accept "button" actionType in product feed schema

### DIFF
--- a/.changeset/fix-product-feed-action-type-button.md
+++ b/.changeset/fix-product-feed-action-type-button.md
@@ -1,0 +1,5 @@
+---
+"@nike-release-checker/sdk": patch
+---
+
+Accept `button` as a valid `actionType` in the product feed `ActionSchema` to handle API responses (e.g. US marketplace) that include this value alongside `cta_buying_tools` and `minicard_link`.

--- a/packages/sdk/productFeed/schema.ts
+++ b/packages/sdk/productFeed/schema.ts
@@ -587,7 +587,11 @@ export const DestinationSchema = v.object({
 })
 
 export const ActionSchema = v.object({
-	actionType: v.union([v.literal('cta_buying_tools'), v.literal('minicard_link')]),
+	actionType: v.union([
+		v.literal('button'),
+		v.literal('cta_buying_tools'),
+		v.literal('minicard_link'),
+	]),
 	analytics: AnalyticsSchema,
 	destination: DestinationSchema,
 	destinationId: v.optional(v.string()),


### PR DESCRIPTION
The US product feed returns `actionType: "button"` for some action nodes,
which previously failed validation against the existing `cta_buying_tools` /
`minicard_link` union.